### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/kledderen/d51fa8dd-0d0b-4710-8dea-427a0c9989f3/561dca0a-dab2-4c4f-9430-299ceaa92f38/_apis/work/boardbadge/df7f7422-212e-4dfc-8737-372147097384)](https://dev.azure.com/kledderen/d51fa8dd-0d0b-4710-8dea-427a0c9989f3/_boards/board/t/561dca0a-dab2-4c4f-9430-299ceaa92f38/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/kledderen/d51fa8dd-0d0b-4710-8dea-427a0c9989f3/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.